### PR TITLE
Remove the brackets `listener_arns` to correct count

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -45,7 +45,7 @@ output "https_listener_arn" {
 
 output "listener_arns" {
   description = "A list of all the listener ARNs"
-  value       = ["${compact(concat(aws_lb_listener.http.*.arn, aws_lb_listener.https.*.arn))}"]
+  value       = "${compact(concat(aws_lb_listener.http.*.arn, aws_lb_listener.https.*.arn))}"
 }
 
 output "access_logs_bucket_id" {


### PR DESCRIPTION
## what 

Remove brackets for listener_arns

## why

was failing on anything larger than 1 with
```
index 1 out of range for list var.listener_arns (max 1) in:

${var.listener_arns[1]}
```

## references

https://github.com/hashicorp/terraform/issues/14521#issuecomment-303492203