### PR TITLE
Adding default target group port to accomodate for a TG with a port other than 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Available targets:
 | stage | Stage, e.g. `prod`, `staging`, `dev`, or `test` | string | - | yes |
 | subnet_ids | A list of subnet IDs to associate with ALB | list | - | yes |
 | tags | Additional tags (e.g. `map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| target_group_port | The port for the default target group | string | `80` | no |
 | vpc_id | VPC ID to associate with ALB | string | - | yes |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -36,6 +36,7 @@
 | stage | Stage, e.g. `prod`, `staging`, `dev`, or `test` | string | - | yes |
 | subnet_ids | A list of subnet IDs to associate with ALB | list | - | yes |
 | tags | Additional tags (e.g. `map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| target_group_port | The port for the default target group | string | `80` | no |
 | vpc_id | VPC ID to associate with ALB | string | - | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "default_target_group_label" {
 
 resource "aws_lb_target_group" "default" {
   name                 = "${module.default_target_group_label.id}"
-  port                 = "80"
+  port                 = "${var.target_group_port}"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"
   target_type          = "ip"

--- a/variables.tf
+++ b/variables.tf
@@ -201,3 +201,8 @@ variable "alb_access_logs_s3_bucket_force_destroy" {
   description = "A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error"
   default     = false
 }
+
+variable "target_group_port" {
+  description = "The port for the default target group"
+  default     = "80"
+}


### PR DESCRIPTION
This is to enable the option to specify the default target group port in the cases that the service does not listen on port 80.