### PR TITLE
Added var for SSL policy changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Available targets:
 | https_ingress_cidr_blocks | List of CIDR blocks to allow in HTTPS security group | list | `<list>` | no |
 | https_ingress_prefix_list_ids | List of prefix list IDs for allowing access to HTTPS ingress security group | list | `<list>` | no |
 | https_port | The port for the HTTPS listener | string | `443` | no |
+| https_ssl_policy | The name of the SSL Policy for the listener. | string | `ELBSecurityPolicy-2015-05` | no |
 | idle_timeout | The time in seconds that the connection is allowed to be idle | string | `60` | no |
 | internal | A boolean flag to determine whether the ALB should be internal | string | `false` | no |
 | ip_address_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | string | `ipv4` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -27,6 +27,7 @@
 | https_ingress_cidr_blocks | List of CIDR blocks to allow in HTTPS security group | list | `<list>` | no |
 | https_ingress_prefix_list_ids | List of prefix list IDs for allowing access to HTTPS ingress security group | list | `<list>` | no |
 | https_port | The port for the HTTPS listener | string | `443` | no |
+| https_ssl_policy | The name of the SSL Policy for the listener. | string | `ELBSecurityPolicy-2015-05` | no |
 | idle_timeout | The time in seconds that the connection is allowed to be idle | string | `60` | no |
 | internal | A boolean flag to determine whether the ALB should be internal | string | `false` | no |
 | ip_address_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | string | `ipv4` | no |

--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ resource "aws_lb_listener" "https" {
 
   port            = "${var.https_port}"
   protocol        = "HTTPS"
-  ssl_policy      = "ELBSecurityPolicy-2015-05"
+  ssl_policy      = "${var.https_ssl_policy}"
   certificate_arn = "${var.certificate_arn}"
 
   default_action {

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,11 @@ variable "https_ingress_prefix_list_ids" {
   description = "List of prefix list IDs for allowing access to HTTPS ingress security group"
 }
 
+variable "https_ssl_policy" {
+  description = "The name of the SSL Policy for the listener."
+  default     = "ELBSecurityPolicy-2015-05"
+}
+
 variable "access_logs_prefix" {
   type        = "string"
   default     = ""


### PR DESCRIPTION
The SSL policy is outdated and consumers may choose to use different values.

@aknysh @osterman 