### PR TITLE
Allow customizing the default target group name, target type, and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,10 @@ Available targets:
 | stage | Stage, e.g. `prod`, `staging`, `dev`, or `test` | string | - | yes |
 | subnet_ids | A list of subnet IDs to associate with ALB | list | - | yes |
 | tags | Additional tags (e.g. `map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| target_group_name | The name for the default target group, uses a module label name if left empty | string | `` | no |
 | target_group_port | The port for the default target group | string | `80` | no |
+| target_group_tags | The tags to apply to the target group, uses module tags if left empty | map | `<map>` | no |
+| target_group_target_type | The type (instance, ip or lambda) of targets that can be registered with the target group | string | `ip` | no |
 | vpc_id | VPC ID to associate with ALB | string | - | yes |
 
 ## Outputs
@@ -276,13 +279,13 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://github.com/goruha.png?size=150
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [sarkis_homepage]: https://github.com/sarkis
-  [sarkis_avatar]: https://github.com/sarkis.png?size=150
+  [sarkis_avatar]: https://img.cloudposse.com/150x150/https://github.com/sarkis.png
 
 
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ Available targets:
 | stage | Stage, e.g. `prod`, `staging`, `dev`, or `test` | string | - | yes |
 | subnet_ids | A list of subnet IDs to associate with ALB | list | - | yes |
 | tags | Additional tags (e.g. `map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| target_group_additional_tags | The additional tags to apply to the target group | map | `<map>` | no |
 | target_group_name | The name for the default target group, uses a module label name if left empty | string | `` | no |
 | target_group_port | The port for the default target group | string | `80` | no |
-| target_group_tags | The tags to apply to the target group, uses module tags if left empty | map | `<map>` | no |
 | target_group_target_type | The type (instance, ip or lambda) of targets that can be registered with the target group | string | `ip` | no |
 | vpc_id | VPC ID to associate with ALB | string | - | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -37,9 +37,9 @@
 | stage | Stage, e.g. `prod`, `staging`, `dev`, or `test` | string | - | yes |
 | subnet_ids | A list of subnet IDs to associate with ALB | list | - | yes |
 | tags | Additional tags (e.g. `map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| target_group_additional_tags | The additional tags to apply to the target group | map | `<map>` | no |
 | target_group_name | The name for the default target group, uses a module label name if left empty | string | `` | no |
 | target_group_port | The port for the default target group | string | `80` | no |
-| target_group_tags | The tags to apply to the target group, uses module tags if left empty | map | `<map>` | no |
 | target_group_target_type | The type (instance, ip or lambda) of targets that can be registered with the target group | string | `ip` | no |
 | vpc_id | VPC ID to associate with ALB | string | - | yes |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -37,10 +37,7 @@
 | stage | Stage, e.g. `prod`, `staging`, `dev`, or `test` | string | - | yes |
 | subnet_ids | A list of subnet IDs to associate with ALB | list | - | yes |
 | tags | Additional tags (e.g. `map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
-| target_group_name | The name for the default target group, uses a module label name if left empty | string | `` | no |
 | target_group_port | The port for the default target group | string | `80` | no |
-| target_group_tags | The tags to apply to the target group, uses module tags if left empty | map | `<map>` | no |
-| target_group_target_type | The type (instance, ip or lambda) of targets that can be registered with the target group | string | `ip` | no |
 | vpc_id | VPC ID to associate with ALB | string | - | yes |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -37,7 +37,10 @@
 | stage | Stage, e.g. `prod`, `staging`, `dev`, or `test` | string | - | yes |
 | subnet_ids | A list of subnet IDs to associate with ALB | list | - | yes |
 | tags | Additional tags (e.g. `map(`BusinessUnit`,`XYZ`) | map | `<map>` | no |
+| target_group_name | The name for the default target group, uses a module label name if left empty | string | `` | no |
 | target_group_port | The port for the default target group | string | `80` | no |
+| target_group_tags | The tags to apply to the target group, uses module tags if left empty | map | `<map>` | no |
+| target_group_target_type | The type (instance, ip or lambda) of targets that can be registered with the target group | string | `ip` | no |
 | vpc_id | VPC ID to associate with ALB | string | - | yes |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -89,11 +89,11 @@ module "default_target_group_label" {
 }
 
 resource "aws_lb_target_group" "default" {
-  name                 = "${module.default_target_group_label.id}"
+  name                 = "${var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name}"
   port                 = "${var.target_group_port}"
   protocol             = "HTTP"
   vpc_id               = "${var.vpc_id}"
-  target_type          = "ip"
+  target_type          = "${var.target_group_target_type}"
   deregistration_delay = "${var.deregistration_delay}"
 
   health_check {
@@ -108,6 +108,8 @@ resource "aws_lb_target_group" "default" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = "${length(var.target_group_tags) == 0 ? module.default_target_group_label.tags : var.target_group_tags}"
 }
 
 resource "aws_lb_listener" "http" {

--- a/main.tf
+++ b/main.tf
@@ -109,7 +109,7 @@ resource "aws_lb_target_group" "default" {
     create_before_destroy = true
   }
 
-  tags = "${length(var.target_group_tags) == 0 ? module.default_target_group_label.tags : var.target_group_tags}"
+  tags = "${merge(module.default_target_group_label.tags, var.target_group_additional_tags)}"
 }
 
 resource "aws_lb_listener" "http" {

--- a/variables.tf
+++ b/variables.tf
@@ -224,8 +224,8 @@ variable "target_group_target_type" {
   description = "The type (instance, ip or lambda) of targets that can be registered with the target group"
 }
 
-variable "target_group_tags" {
+variable "target_group_additional_tags" {
   type        = "map"
   default     = {}
-  description = "The tags to apply to the target group, uses module tags if left empty"
+  description = "The additional tags to apply to the target group"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -211,3 +211,21 @@ variable "target_group_port" {
   description = "The port for the default target group"
   default     = "80"
 }
+
+variable "target_group_name" {
+  type        = "string"
+  default     = ""
+  description = "The name for the default target group, uses a module label name if left empty"
+}
+
+variable "target_group_target_type" {
+  type        = "string"
+  default     = "ip"
+  description = "The type (instance, ip or lambda) of targets that can be registered with the target group"
+}
+
+variable "target_group_tags" {
+  type        = "map"
+  default     = {}
+  description = "The tags to apply to the target group, uses module tags if left empty"
+}


### PR DESCRIPTION
This adds 3 new variables (with original defaults to maintain backwards compatibility with older module versions) to the default target group.

1. `target_group_name` - while the default naming scheme enforced by the null-label is nice, I have found valid use cases for specifying a more descriptive custom name for the default target group (while still preserving the naming scheme for the actual ALB).
2. `target_group_target_type` - AWS has three options for target group types, this allows for specifying an option other than the hardcoded `ip`.
3. `target_group_tags` - before this change, the default target group did not have its tags set by the module. This updates it to either optionally pass in your own set of tags (something that I think is useful, just like being able to specify your own target group name) or use the tags passed in to the module that are also applied to the ALB.