### PR TITLE
Added random, updated name and added protocol var

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,10 +96,21 @@ module "default_target_group_label" {
   tags        = var.tags
 }
 
+resource "random_id" "alb_tg" {
+  byte_length = 8
+  keepers = {
+    name                 = var.target_group_name
+    port                 = var.target_group_port
+    protocol             = var.target_group_protocol
+    vpc_id               = var.vpc_id
+    target_type          = var.target_group_target_type
+  }
+}
+
 resource "aws_lb_target_group" "default" {
-  name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
+  name                 = var.target_group_name == "" ? join(module.default_target_group_label.delimiter, [module.default_target_group_label.id ,random_id.alb_tg.hex]) : var.target_group_name
   port                 = var.target_group_port
-  protocol             = "HTTP"
+  protocol             = var.target_group_protocol
   vpc_id               = var.vpc_id
   target_type          = var.target_group_target_type
   deregistration_delay = var.deregistration_delay

--- a/variables.tf
+++ b/variables.tf
@@ -229,6 +229,12 @@ variable "target_group_port" {
   description = "The port for the default target group"
 }
 
+variable "target_group_protocol" {
+  type        = string
+  default     = "HTTP"
+  description = "The protocol to use to connect with the target"
+}
+
 variable "target_group_name" {
   type        = string
   default     = ""

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,6 @@ terraform {
     template = "~> 2.0"
     null     = "~> 2.0"
     local    = "~> 1.3"
+    random   = "~> 2.2"
   }
 }


### PR DESCRIPTION
Added variable for the protocol as it was set to always be HTTP. 

Added random target group name using random suffix. This helps when some properties, such as target group protocol need to be changed, which triggers a replace. There can be a name conflict if you are using the default naming from the module. The random string has triggers on the values that enables a successful create before destroy to happen.