### PR TITLE
Fix tests

### DIFF
--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -24,7 +24,7 @@ func TestExamplesComplete(t *testing.T) {
 		// Variables to pass to our Terraform code using -var-file options
 		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 		Vars: map[string]interface{}{
-			"attributes": myList,
+			"attributes": attributes,
 		},
 	}
 
@@ -51,8 +51,8 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	accessLogsBucketId := terraform.Output(t, terraformOptions, "access_logs_bucket_id")
-	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-alb-alb-access-logs-"+attributes[0], accessLogsBucketId)
+	// Verify we're getting back the outputs we expect eg-test-alb-25346-alb-access-logs
+	assert.Equal(t, "eg-test-alb-"+attributes[0]+"-alb-access-logs", accessLogsBucketId)
 
 	// Run `terraform output` to get the value of an output variable
 	albName := terraform.Output(t, terraformOptions, "alb_name")
@@ -61,8 +61,8 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	defaultTargetGroupArn := terraform.Output(t, terraformOptions, "default_target_group_arn")
-	// Verify we're getting back the outputs we expect
-	assert.Contains(t, defaultTargetGroupArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:targetgroup/eg-test-alb-default-"+attributes[0])
+	// Verify we're getting back the outputs we expect something like "arn:aws:elasticloadbalancing:us-east-2:126450723953:targetgroup/eg-test-alb-11514-default/89e9fe401fc63cf7
+	assert.Contains(t, defaultTargetGroupArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:targetgroup/eg-test-alb-"+attributes[0]+"-default")
 
 	// Run `terraform output` to get the value of an output variable
 	httpListenerArn := terraform.Output(t, terraformOptions, "http_listener_arn")

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -5,11 +5,17 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
+	"math/rand"
+	"strconv"
+	"time"
 )
 
 // Test the Terraform module in examples/complete using Terratest.
 func TestExamplesComplete(t *testing.T) {
 	t.Parallel()
+	rand.Seed(time.Now().UnixNano())
+
+	attributes := []string{strconv.Itoa(rand.Intn(100000))}
 
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
@@ -17,6 +23,9 @@ func TestExamplesComplete(t *testing.T) {
 		Upgrade:      true,
 		// Variables to pass to our Terraform code using -var-file options
 		VarFiles: []string{"fixtures.us-east-2.tfvars"},
+		Vars: map[string]interface{}{
+			"attributes": myList,
+		},
 	}
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
@@ -43,20 +52,20 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	accessLogsBucketId := terraform.Output(t, terraformOptions, "access_logs_bucket_id")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-alb-alb-access-logs", accessLogsBucketId)
+	assert.Equal(t, "eg-test-alb-alb-access-logs-"+attributes[0], accessLogsBucketId)
 
 	// Run `terraform output` to get the value of an output variable
 	albName := terraform.Output(t, terraformOptions, "alb_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-alb", albName)
+	assert.Equal(t, "eg-test-alb-"+attributes[0], albName)
 
 	// Run `terraform output` to get the value of an output variable
 	defaultTargetGroupArn := terraform.Output(t, terraformOptions, "default_target_group_arn")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, defaultTargetGroupArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:targetgroup/eg-test-alb-default")
+	assert.Contains(t, defaultTargetGroupArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:targetgroup/eg-test-alb-default-"+attributes[0])
 
 	// Run `terraform output` to get the value of an output variable
 	httpListenerArn := terraform.Output(t, terraformOptions, "http_listener_arn")
 	// Verify we're getting back the outputs we expect
-	assert.Contains(t, httpListenerArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:listener/app/eg-test-alb")
+	assert.Contains(t, httpListenerArn, "arn:aws:elasticloadbalancing:us-east-2:126450723953:listener/app/eg-test-alb-"+attributes[0])
 }


### PR DESCRIPTION
## what
* generate a unique bucket resource by passing a random attribute

## why
tests fail because someone on the interwebs has used our default example and left the bucket laying out
