### PR TITLE
bump aws-lb-s3-bucket version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.4.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.5.0"
   enabled                            = var.access_logs_enabled
   name                               = var.name
   namespace                          = var.namespace


### PR DESCRIPTION
## what
* change version of terraform-aws-lb-s3-bucket module

## why
* version 0.4.0 doesn't work with terraform 0.13.0



