### PR TITLE
fix: update upsteam dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.5.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.7.0"
   enabled                            = var.access_logs_enabled
   name                               = var.name
   namespace                          = var.namespace


### PR DESCRIPTION
## what
* module `access_logs` is using tagged version that has issues with TF 0.13, so updating to use a fixed version of that module

## why
* this module currently fails with TF 0.13, and has no tests for TF 0.13 to automatically detect these issues


