### PR TITLE
Add enabled variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Available targets:
 | delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | deregistration\_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
 | enable\_glacier\_transition | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
 | glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,6 +30,7 @@
 | delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
 | deregistration\_delay | The amount of time to wait in seconds before changing the state of a deregistering target to unused | `number` | `15` | no |
 | enable\_glacier\_transition | Enables the transition of lb logs to AWS Glacier | `bool` | `true` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
 | environment | Environment, e.g. 'prod', 'staging', 'dev', 'pre-prod', 'UAT' | `string` | `""` | no |
 | expiration\_days | Number of days after which to expunge s3 logs | `number` | `90` | no |
 | glacier\_transition\_days | Number of days after which to move s3 logs to the glacier storage tier | `number` | `60` | no |

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ module "default_label" {
 }
 
 resource "aws_security_group" "default" {
+  count       = var.enabled ? 1 : 0
   description = "Controls access to the ALB (HTTP/HTTPS)"
   vpc_id      = var.vpc_id
   name        = module.default_label.id
@@ -17,39 +18,40 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_security_group_rule" "egress" {
+  count             = var.enabled ? 1 : 0
   type              = "egress"
   from_port         = "0"
   to_port           = "0"
   protocol          = "-1"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.default.id
+  security_group_id = join("", aws_security_group.default.*.id)
 }
 
 resource "aws_security_group_rule" "http_ingress" {
-  count             = var.http_enabled ? 1 : 0
+  count             = var.enabled && var.http_enabled ? 1 : 0
   type              = "ingress"
   from_port         = var.http_port
   to_port           = var.http_port
   protocol          = "tcp"
   cidr_blocks       = var.http_ingress_cidr_blocks
   prefix_list_ids   = var.http_ingress_prefix_list_ids
-  security_group_id = aws_security_group.default.id
+  security_group_id = join("", aws_security_group.default.*.id)
 }
 
 resource "aws_security_group_rule" "https_ingress" {
-  count             = var.https_enabled ? 1 : 0
+  count             = var.enabled && var.https_enabled ? 1 : 0
   type              = "ingress"
   from_port         = var.https_port
   to_port           = var.https_port
   protocol          = "tcp"
   cidr_blocks       = var.https_ingress_cidr_blocks
   prefix_list_ids   = var.https_ingress_prefix_list_ids
-  security_group_id = aws_security_group.default.id
+  security_group_id = join("", aws_security_group.default.*.id)
 }
 
 module "access_logs" {
   source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.7.0"
-  enabled                            = var.access_logs_enabled
+  enabled                            = var.enabled && var.access_logs_enabled
   name                               = var.name
   namespace                          = var.namespace
   stage                              = var.stage
@@ -69,13 +71,14 @@ module "access_logs" {
 }
 
 resource "aws_lb" "default" {
+  count              = var.enabled ? 1 : 0
   name               = module.default_label.id
   tags               = module.default_label.tags
   internal           = var.internal
   load_balancer_type = "application"
 
   security_groups = compact(
-    concat(var.security_group_ids, [aws_security_group.default.id]),
+    concat(var.security_group_ids, [join("", aws_security_group.default.*.id)]),
   )
 
   subnets                          = var.subnet_ids
@@ -104,6 +107,7 @@ module "default_target_group_label" {
 }
 
 resource "aws_lb_target_group" "default" {
+  count                = var.enabled ? 1 : 0
   name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
   port                 = var.target_group_port
   protocol             = var.target_group_protocol
@@ -142,24 +146,24 @@ resource "aws_lb_target_group" "default" {
 
 resource "aws_lb_listener" "http_forward" {
   count             = var.http_enabled && var.http_redirect != true ? 1 : 0
-  load_balancer_arn = aws_lb.default.arn
+  load_balancer_arn = join("", aws_lb.default.*.arn)
   port              = var.http_port
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_lb_target_group.default.arn
+    target_group_arn = join("", aws_lb_target_group.default.*.arn)
     type             = "forward"
   }
 }
 
 resource "aws_lb_listener" "http_redirect" {
-  count             = var.http_enabled && var.http_redirect == true ? 1 : 0
-  load_balancer_arn = aws_lb.default.arn
+  count             = var.enabled && var.http_enabled && var.http_redirect == true ? 1 : 0
+  load_balancer_arn = join("", aws_lb.default.*.arn)
   port              = var.http_port
   protocol          = "HTTP"
 
   default_action {
-    target_group_arn = aws_lb_target_group.default.arn
+    target_group_arn = join("", aws_lb_target_group.default.*.arn)
     type             = "redirect"
 
     redirect {
@@ -171,8 +175,8 @@ resource "aws_lb_listener" "http_redirect" {
 }
 
 resource "aws_lb_listener" "https" {
-  count             = var.https_enabled ? 1 : 0
-  load_balancer_arn = aws_lb.default.arn
+  count             = var.enabled && var.https_enabled ? 1 : 0
+  load_balancer_arn = join("", aws_lb.default.*.arn)
 
   port            = var.https_port
   protocol        = "HTTPS"
@@ -180,7 +184,7 @@ resource "aws_lb_listener" "https" {
   certificate_arn = var.certificate_arn
 
   default_action {
-    target_group_arn = aws_lb_target_group.default.arn
+    target_group_arn = join("", aws_lb_target_group.default.*.arn)
     type             = "forward"
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,36 +1,36 @@
 output "alb_name" {
   description = "The ARN suffix of the ALB"
-  value       = aws_lb.default.name
+  value       = join("", aws_lb.default.*.name)
 }
 
 output "alb_arn" {
   description = "The ARN of the ALB"
-  value       = aws_lb.default.arn
+  value       = join("", aws_lb.default.*.arn)
 }
 
 output "alb_arn_suffix" {
   description = "The ARN suffix of the ALB"
-  value       = aws_lb.default.arn_suffix
+  value       = join("", aws_lb.default.*.arn_suffix)
 }
 
 output "alb_dns_name" {
   description = "DNS name of ALB"
-  value       = aws_lb.default.dns_name
+  value       = join("", aws_lb.default.*.dns_name)
 }
 
 output "alb_zone_id" {
   description = "The ID of the zone which ALB is provisioned"
-  value       = aws_lb.default.zone_id
+  value       = join("", aws_lb.default.*.zone_id)
 }
 
 output "security_group_id" {
   description = "The security group ID of the ALB"
-  value       = aws_security_group.default.id
+  value       = join("", aws_security_group.default.*.id)
 }
 
 output "default_target_group_arn" {
   description = "The default target group ARN"
-  value       = aws_lb_target_group.default.arn
+  value       = join("", aws_lb_target_group.default.*.arn)
 }
 
 output "http_listener_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Set to false to prevent the module from creating any resources"
+}
+
 variable "namespace" {
   type        = string
   description = "Namespace (e.g. `eg` or `cp`)"


### PR DESCRIPTION
## what
This allows the ALB to be created selectively.

## why
As a cost saving measure, I want to be able to create an ALB per AWS account for a given application and then create multiple target groups.  

## references
* This addresses https://github.com/cloudposse/terraform-aws-alb/issues/55.

