### PR TITLE
update aws providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,13 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0, < 4.0 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -168,7 +169,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0, < 4.0 |
 
 ## Inputs
 
@@ -176,7 +177,6 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
 | alb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
 | certificate\_arn | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
@@ -243,6 +243,7 @@ Available targets:
 | listener\_arns | A list of all the listener ARNs |
 | security\_group\_id | The security group ID of the ALB |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ For automated test of the complete example using `bats` and `Terratest`, see [te
     http_redirect                           = var.http_redirect
     access_logs_enabled                     = var.access_logs_enabled
     alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
-    access_logs_region                      = var.access_logs_region
     cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
     http2_enabled                           = var.http2_enabled
     idle_timeout                            = var.idle_timeout

--- a/README.yaml
+++ b/README.yaml
@@ -69,7 +69,6 @@ usage: |-
       http_redirect                           = var.http_redirect
       access_logs_enabled                     = var.access_logs_enabled
       alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
-      access_logs_region                      = var.access_logs_region
       cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
       http2_enabled                           = var.http2_enabled
       idle_timeout                            = var.idle_timeout

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0, < 4.0 |
 | local | ~> 1.3 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -12,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0, < 4.0 |
 
 ## Inputs
 
@@ -20,7 +21,6 @@
 |------|-------------|------|---------|:--------:|
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
 | alb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
 | certificate\_arn | The ARN of the default SSL certificate for HTTPS listener | `string` | `""` | no |
@@ -87,3 +87,4 @@
 | listener\_arns | A list of all the listener ARNs |
 | security\_group\_id | The security group ID of the ALB |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.7.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.7.1"
   enabled                            = var.access_logs_enabled
   name                               = var.name
   namespace                          = var.namespace
@@ -57,7 +57,6 @@ module "access_logs" {
   attributes                         = compact(concat(var.attributes, ["alb", "access", "logs"]))
   delimiter                          = var.delimiter
   tags                               = var.tags
-  region                             = var.access_logs_region
   lifecycle_rule_enabled             = var.lifecycle_rule_enabled
   enable_glacier_transition          = var.enable_glacier_transition
   expiration_days                    = var.expiration_days

--- a/variables.tf
+++ b/variables.tf
@@ -139,12 +139,6 @@ variable "access_logs_enabled" {
   description = "A boolean flag to enable/disable access_logs"
 }
 
-variable "access_logs_region" {
-  type        = string
-  default     = "us-east-1"
-  description = "The region for the access_logs S3 bucket"
-}
-
 variable "cross_zone_load_balancing_enabled" {
   type        = bool
   default     = true

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = ">= 2.0, < 4.0"
     template = "~> 2.0"
     null     = "~> 2.0"
     local    = "~> 1.3"

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws      = ">= 2.0, < 4.0"
-    template = "~> 2.0"
-    null     = "~> 2.0"
-    local    = "~> 1.3"
+    aws      = ">= 2.0"
+    template = ">= 2.0"
+    null     = ">= 2.0"
+    local    = ">= 1.3"
   }
 }


### PR DESCRIPTION
## what
* support aws 3.x provider
* DEPENDENCY: https://github.com/cloudposse/terraform-aws-lb-s3-bucket/pull/20

## why
* enable using with other modules requiring aws 3.x provider

## references
* requires 3.x: https://github.com/cloudposse/terraform-aws-ecr/blob/master/main.tf#L30
