### PR TITLE
Add alb_name variable to specify load balancer name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ module "access_logs" {
 }
 
 resource "aws_lb" "default" {
-  name               = module.default_label.id
+  name               = var.alb_name == "" ? module.default_label.id : var.alb_name
   tags               = module.default_label.tags
   internal           = var.internal
   load_balancer_type = "application"

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "security_group_ids" {
   description = "A list of additional security group IDs to allow access to ALB"
 }
 
+variable "alb_name" {
+  type        = string
+  default     = ""
+  description = "The name for the load balancer, uses a module label name if left empty"
+}
+
 variable "internal" {
   type        = bool
   default     = false


### PR DESCRIPTION
## What
* Add an `alb_name` variable to avoid using the default label id, if set.

## Why
* According to AWS documentation, the Load Balancer name is limited to 32 characters.
* This adds a way to avoid issues like this one, while maintaining support for setting any labels or tags to the related resource:
```
Error: "name" cannot be longer than 32 characters

  on main.tf line 71, in resource "aws_lb" "default":
  71: resource "aws_lb" "default" {
```

## References
* Slightly related to #27, but for a different field.
* AWS documentation: https://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_CreateLoadBalancer.html

