### PR TITLE
Updated version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,21 +154,22 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.3 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| aws | >= 2.0 |
+| local | >= 1.3 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -243,6 +244,7 @@ Available targets:
 | listener\_arns | A list of all the listener ARNs |
 | security\_group\_id | The security group ID of the ALB |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
+| terraform | >= 0.12.0 |
 | aws | >= 2.0 |
 | local | >= 1.3 |
 | null | >= 2.0 |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
+| terraform | >= 0.12.0 |
 | aws | >= 2.0 |
 | local | >= 1.3 |
 | null | >= 2.0 |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,18 +1,19 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.3 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| aws | >= 2.0 |
+| local | >= 1.3 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -87,3 +88,4 @@
 | listener\_arns | A list of all the listener ARNs |
 | security\_group\_id | The security group ID of the ALB |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
     aws      = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    null     = "~> 2.0"
-    local    = "~> 1.3"
+    aws      = ">= 2.0"
+    template = ">= 2.0"
+    null     = ">= 2.0"
+    local    = ">= 1.3"
   }
 }


### PR DESCRIPTION
The `aws = ~> 2.0` causes error in Terraform 0.13:

```
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints >= 3.0.*, >= 2.0.*, >=
2.0.*, >= 2.0.*, >= 2.0.*, >= 2.0.*, < 4.0.*, ~> 2.0, ~> 2.0, ~> 2.0, ~> 2.0,
~> 2.0, ~> 2.0, >= 2.0.*, < 4.0.*, >= 3.0.*, >= 2.0.*, >= 2.0.*, >= 2.0.*
```

## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

