### PR TITLE
fix: update s3 bucket & context tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,17 @@ name: auto-release
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          publish: true
-          prerelease: false
-          config-name: auto-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        prerelease: false
+        config-name: auto-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -117,7 +117,6 @@ For automated test of the complete example using `bats` and `Terratest`, see [te
     http_redirect                           = var.http_redirect
     access_logs_enabled                     = var.access_logs_enabled
     alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
-    access_logs_region                      = var.access_logs_region
     cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
     http2_enabled                           = var.http2_enabled
     idle_timeout                            = var.idle_timeout
@@ -177,7 +176,6 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | alb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -69,7 +69,6 @@ usage: |-
       http_redirect                           = var.http_redirect
       access_logs_enabled                     = var.access_logs_enabled
       alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
-      access_logs_region                      = var.access_logs_region
       cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
       http2_enabled                           = var.http2_enabled
       idle_timeout                            = var.idle_timeout

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,7 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,7 +21,6 @@
 |------|-------------|------|---------|:--------:|
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| access\_logs\_region | The region for the access\_logs S3 bucket | `string` | `"us-east-1"` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | alb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -19,7 +19,7 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
+  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -20,8 +20,6 @@ access_logs_enabled = true
 
 alb_access_logs_s3_bucket_force_destroy = true
 
-access_logs_region = "us-east-2"
-
 cross_zone_load_balancing_enabled = false
 
 http2_enabled = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,7 +30,6 @@ module "alb" {
   http_redirect                           = var.http_redirect
   access_logs_enabled                     = var.access_logs_enabled
   alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
-  access_logs_region                      = var.access_logs_region
   cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
   http2_enabled                           = var.http2_enabled
   idle_timeout                            = var.idle_timeout

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -33,11 +33,6 @@ variable "access_logs_enabled" {
   description = "A boolean flag to enable/disable access_logs"
 }
 
-variable "access_logs_region" {
-  type        = string
-  description = "The region for the access_logs S3 bucket"
-}
-
 variable "cross_zone_load_balancing_enabled" {
   type        = bool
   description = "A boolean flag to enable/disable cross zone load balancing"

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,6 @@ module "access_logs" {
   attributes                         = compact(concat(module.this.attributes, ["alb", "access", "logs"]))
   delimiter                          = module.this.delimiter
   tags                               = module.this.tags
-  region                             = var.access_logs_region
   lifecycle_rule_enabled             = var.lifecycle_rule_enabled
   enable_glacier_transition          = var.enable_glacier_transition
   expiration_days                    = var.expiration_days

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,9 @@
-module "default_label" {
-  source  = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.19.2"
-  context = module.this.context
-}
-
 resource "aws_security_group" "default" {
   count       = module.this.enabled ? 1 : 0
   description = "Controls access to the ALB (HTTP/HTTPS)"
   vpc_id      = var.vpc_id
-  name        = module.default_label.id
-  tags        = module.default_label.tags
+  name        = module.this.id
+  tags        = module.this.tags
 }
 
 resource "aws_security_group_rule" "egress" {
@@ -44,7 +39,7 @@ resource "aws_security_group_rule" "https_ingress" {
 }
 
 module "access_logs" {
-  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.8.0"
+  source                             = "git::https://github.com/cloudposse/terraform-aws-lb-s3-bucket.git?ref=tags/0.9.0"
   enabled                            = module.this.enabled && var.access_logs_enabled
   name                               = module.this.name
   namespace                          = module.this.namespace
@@ -66,8 +61,8 @@ module "access_logs" {
 
 resource "aws_lb" "default" {
   count              = module.this.enabled ? 1 : 0
-  name               = module.default_label.id
-  tags               = module.default_label.tags
+  name               = module.this.id
+  tags               = module.this.tags
   internal           = var.internal
   load_balancer_type = "application"
 

--- a/variables.tf
+++ b/variables.tf
@@ -98,12 +98,6 @@ variable "access_logs_enabled" {
   description = "A boolean flag to enable/disable access_logs"
 }
 
-variable "access_logs_region" {
-  type        = string
-  default     = "us-east-1"
-  description = "The region for the access_logs S3 bucket"
-}
-
 variable "cross_zone_load_balancing_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* Bump the tag for s3 bucket module to use `>= 2.0` for aws provider to avoid module version conflicts when used with >= 3.0 modules (eg. aws-eks-node-group).
* Bump the tag to `0.21.0` for `terraform-null-label` module to support future versions of TF.

## why
* This module is being used with [terraform-aws-eks-node-group](https://github.com/cloudposse/terraform-aws-eks-node-group) which needs aws provider version to be >= 2.0 to fix version conflicts.

## references
* See cloudposse/terraform-aws-eks-node-group#41 for details. This tackles one of the modules causing the issue.

