### PR TITLE
Add health_check_path to allow the health check to use a port other than traffic-port

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Available targets:
 | health\_check\_interval | The duration in seconds in between health checks | `number` | `15` | no |
 | health\_check\_matcher | The HTTP response codes to indicate a healthy check | `string` | `"200-399"` | no |
 | health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
+| health\_check\_port | The port to use for the healthcheck | `string` | `"traffic-port"` | no |
 | health\_check\_timeout | The amount of time to wait in seconds before failing a health check request | `number` | `10` | no |
 | health\_check\_unhealthy\_threshold | The number of consecutive health check failures required before considering the target unhealthy | `number` | `2` | no |
 | http2\_enabled | A boolean flag to enable/disable HTTP/2 | `bool` | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -39,6 +39,7 @@
 | health\_check\_interval | The duration in seconds in between health checks | `number` | `15` | no |
 | health\_check\_matcher | The HTTP response codes to indicate a healthy check | `string` | `"200-399"` | no |
 | health\_check\_path | The destination for the health check request | `string` | `"/"` | no |
+| health\_check\_port | The port to use for the healthcheck | `string` | `"traffic-port"` | no |
 | health\_check\_timeout | The amount of time to wait in seconds before failing a health check request | `number` | `10` | no |
 | health\_check\_unhealthy\_threshold | The number of consecutive health check failures required before considering the target unhealthy | `number` | `2` | no |
 | http2\_enabled | A boolean flag to enable/disable HTTP/2 | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "default_target_group_label" {
 }
 
 resource "aws_lb_target_group" "default" {
-  count                = module.this.enabled ? 1 : 0
+  count                = module.this.enabled && module.this.enable_default_target_group ? 1 : 0
   name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
   port                 = var.target_group_port
   protocol             = var.target_group_protocol

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "default_target_group_label" {
 }
 
 resource "aws_lb_target_group" "default" {
-  count                = module.this.enabled && module.this.enable_default_target_group ? 1 : 0
+  count                = module.this.enabled ? 1 : 0
   name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
   port                 = var.target_group_port
   protocol             = var.target_group_protocol

--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ resource "aws_lb_target_group" "default" {
   health_check {
     protocol            = var.target_group_protocol
     path                = var.health_check_path
+    port                = var.health_check_port
     timeout             = var.health_check_timeout
     healthy_threshold   = var.health_check_healthy_threshold
     unhealthy_threshold = var.health_check_unhealthy_threshold

--- a/variables.tf
+++ b/variables.tf
@@ -182,12 +182,6 @@ variable "alb_access_logs_s3_bucket_force_destroy" {
   description = "A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error"
 }
 
-variable "enable_default_target_group" {
-    type        = bool
-    default     = true
-    description = "A boolean that indicates if the module should create a default target group for the ALB."
-}
-
 variable "target_group_port" {
   type        = number
   default     = 80

--- a/variables.tf
+++ b/variables.tf
@@ -176,6 +176,12 @@ variable "alb_access_logs_s3_bucket_force_destroy" {
   description = "A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error"
 }
 
+variable "enable_default_target_group" {
+    type        = bool
+    default     = true
+    description = "A boolean that indicates if the module should create a default target group for the ALB."
+}
+
 variable "target_group_port" {
   type        = number
   default     = 80

--- a/variables.tf
+++ b/variables.tf
@@ -140,6 +140,12 @@ variable "health_check_path" {
   description = "The destination for the health check request"
 }
 
+variable "health_check_port" {
+  type        = string
+  default     = "traffic-port"
+  description = "The port to use for the healthcheck"
+}
+
 variable "health_check_timeout" {
   type        = number
   default     = 10


### PR DESCRIPTION
## what
* Allows the specification of a health check port that is not the traffic-port.

## why
* The health check endpoint doesn't necessarily always exist on the default traffic-port, as is my case.

