### PR TITLE
Adding SNI cert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| additional\_certs | A list of additonal certs to add to the https listerner | `list` | n/a | yes |
+| additional\_certs | A list of additonal certs to add to the https listerner | `list(string)` | `[]` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | alb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,6 +21,7 @@
 |------|-------------|------|---------|:--------:|
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
+| additional\_certs | A list of additonal certs to add to the https listerner | `list` | n/a | yes |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | alb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -21,7 +21,7 @@
 |------|-------------|------|---------|:--------:|
 | access\_logs\_enabled | A boolean flag to enable/disable access\_logs | `bool` | `true` | no |
 | access\_logs\_prefix | The S3 log bucket prefix | `string` | `""` | no |
-| additional\_certs | A list of additonal certs to add to the https listerner | `list` | n/a | yes |
+| additional\_certs | A list of additonal certs to add to the https listerner | `list(string)` | `[]` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | alb\_access\_logs\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -262,3 +262,8 @@ variable "stickiness" {
   description = "Target group sticky configuration"
   default     = null
 }
+
+variable "additional_certs" {
+  type        = list
+  description = "A list of additonal certs to add to the https listerner"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -266,5 +266,5 @@ variable "stickiness" {
 variable "additional_certs" {
   type        = list(string)
   description = "A list of additonal certs to add to the https listerner"
-  default = []
+  default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -264,7 +264,7 @@ variable "stickiness" {
 }
 
 variable "additional_certs" {
-  type        = list{string}
+  type        = list(string)
   description = "A list of additonal certs to add to the https listerner"
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -264,6 +264,7 @@ variable "stickiness" {
 }
 
 variable "additional_certs" {
-  type        = list
+  type        = list{string}
   description = "A list of additonal certs to add to the https listerner"
+  default = []
 }


### PR DESCRIPTION
## what
* Enable SNI support for https listener when https listener is enabled

## why
* many times an alb is reuse for multiple urls and with SNI support we can attach multiple certs to the same listener

## references
* https://aws.amazon.com/blogs/aws/new-application-load-balancer-sni/

