### PR TITLE
Add fixed response option on listeners (http or https)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Available targets:
 | ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | lifecycle\_rule\_enabled | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
+| listener\_http\_fixed\_response | Have the HTTP listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
+| listener\_https\_fixed\_response | Have the HTTPS listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
@@ -349,7 +351,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -60,6 +60,8 @@
 | ip\_address\_type | The type of IP addresses used by the subnets for your load balancer. The possible values are `ipv4` and `dualstack`. | `string` | `"ipv4"` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | lifecycle\_rule\_enabled | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
+| listener\_http\_fixed\_response | Have the HTTP listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
+| listener\_https\_fixed\_response | Have the HTTPS listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -214,7 +214,7 @@ variable "target_group_additional_tags" {
 
 variable "listener_http_fixed_response" {
   description = "Have the HTTP listener return a fixed response for the default action."
-  type        = object({
+  type = object({
     content_type = string
     message_body = string
     status_code  = string
@@ -224,7 +224,7 @@ variable "listener_http_fixed_response" {
 
 variable "listener_https_fixed_response" {
   description = "Have the HTTPS listener return a fixed response for the default action."
-  type        = object({
+  type = object({
     content_type = string
     message_body = string
     status_code  = string

--- a/variables.tf
+++ b/variables.tf
@@ -212,6 +212,26 @@ variable "target_group_additional_tags" {
   description = "The additional tags to apply to the target group"
 }
 
+variable "listener_http_fixed_response" {
+  description = "Have the HTTP listener return a fixed response for the default action."
+  type        = object({
+    content_type = string
+    message_body = string
+    status_code  = string
+  })
+  default = null
+}
+
+variable "listener_https_fixed_response" {
+  description = "Have the HTTPS listener return a fixed response for the default action."
+  type        = object({
+    content_type = string
+    message_body = string
+    status_code  = string
+  })
+  default = null
+}
+
 variable "lifecycle_rule_enabled" {
   type        = bool
   description = "A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled."


### PR DESCRIPTION
## what
* Add an optional fixed response to the default auction of the listener (http or https).

## why
* I have a case where I am using a Cloudfront distribution that passes a special header to verify the validity of the request (as described here https://www.arhs-group.com/protecting-aws-alb-behind-aws-cloudfront-distribution/). I want to use a listener rule to respond with a 403 if that header is missing or incorrect. Since the module always forwards to the TG unconditionally, I am adding this feature as an alternative.

