### PR TITLE
Pass module.this.context to cloudposse/lb-s3-bucket/aws

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ module "access_logs" {
   noncurrent_version_transition_days = var.noncurrent_version_transition_days
   standard_transition_days           = var.standard_transition_days
   force_destroy                      = var.alb_access_logs_s3_bucket_force_destroy
+  context                            = module.this.context
 }
 
 resource "aws_lb" "default" {

--- a/main.tf
+++ b/main.tf
@@ -42,13 +42,7 @@ module "access_logs" {
   source                             = "cloudposse/lb-s3-bucket/aws"
   version                            = "0.11.4"
   enabled                            = module.this.enabled && var.access_logs_enabled && var.access_logs_s3_bucket_id == null
-  name                               = module.this.name
-  namespace                          = module.this.namespace
-  stage                              = module.this.stage
-  environment                        = module.this.environment
   attributes                         = compact(concat(module.this.attributes, ["alb", "access", "logs"]))
-  delimiter                          = module.this.delimiter
-  tags                               = module.this.tags
   lifecycle_rule_enabled             = var.lifecycle_rule_enabled
   enable_glacier_transition          = var.enable_glacier_transition
   expiration_days                    = var.expiration_days

--- a/main.tf
+++ b/main.tf
@@ -55,6 +55,8 @@ module "access_logs" {
 }
 
 resource "aws_lb" "default" {
+  #bridgecrew:skip=BC_AWS_NETWORKING_41 - Skipping Ensure that ALB Drops HTTP Headers
+  #bridgecrew:skip=BC_AWS_LOGGING_22 - Skipping Ensure ELBv2 has Access Logging Enabled
   count              = module.this.enabled ? 1 : 0
   name               = module.this.id
   tags               = module.this.tags
@@ -127,6 +129,8 @@ resource "aws_lb_target_group" "default" {
 }
 
 resource "aws_lb_listener" "http_forward" {
+  #bridgecrew:skip=BC_AWS_GENERAL_43 - Skipping Ensure that load balancer is using TLS 1.2.
+  #bridgecrew:skip=BC_AWS_NETWORKING_29 - Skipping Ensure ALB Protocol is HTTPS
   count             = var.http_enabled && var.http_redirect != true ? 1 : 0
   load_balancer_arn = join("", aws_lb.default.*.arn)
   port              = var.http_port
@@ -166,6 +170,7 @@ resource "aws_lb_listener" "http_redirect" {
 }
 
 resource "aws_lb_listener" "https" {
+  #bridgecrew:skip=BC_AWS_GENERAL_43 - Skipping Ensure that load balancer is using TLS 1.2.
   count             = module.this.enabled && var.https_enabled ? 1 : 0
   load_balancer_arn = join("", aws_lb.default.*.arn)
 


### PR DESCRIPTION
## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

- Context, as inherited from the user defined context, is passed and used in the access_logs

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

- Bug found where the s3 bucket was not using our defined context label_order `label_order              = ["namespace", "environment", "name", "attributes"]`.  The bucket being created was still using our defined stage of prod.  In our use case, if the context is passed in, label_order will be respected by the lb-s3-bucket.
- This  change, however, could have repercussions if the the label orders lets say does not have attributes in it, which could try and create buckets that could collide in naming (depending on user setup and resources).
- We are accepting if this PR is rejected that it's possible to create your own bucket and pass it in; which is an acceptable solution

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

N/A in this case
