### PR TITLE
Remove unused template provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ Available targets:
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -7,7 +7,6 @@
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.54 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = ">= 2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.54"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     local = {
       source  = "hashicorp/local"
       version = ">= 1.3"


### PR DESCRIPTION
## what
* remove unused template provider

## why
* broken on darwin-arm64

## references
```
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a
│ package available for your current platform, darwin_arm64.
│ 
│ Provider releases are separate from Terraform CLI releases, so not all
│ providers are available for all platforms. Other versions of this provider
│ may have different platforms supported.
```