### PR TITLE
Ensure target group and load balancer names cannot exceed their max length

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Available targets:
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.13.0 |
+| <a name="module_default_load_balancer_label"></a> [default\_load\_balancer\_label](#module\_default\_load\_balancer\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
@@ -272,6 +273,8 @@ Available targets:
 | <a name="input_lifecycle_rule_enabled"></a> [lifecycle\_rule\_enabled](#input\_lifecycle\_rule\_enabled) | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
 | <a name="input_listener_http_fixed_response"></a> [listener\_http\_fixed\_response](#input\_listener\_http\_fixed\_response) | Have the HTTP listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
 | <a name="input_listener_https_fixed_response"></a> [listener\_https\_fixed\_response](#input\_listener\_https\_fixed\_response) | Have the HTTPS listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
+| <a name="input_load_balancer_name"></a> [load\_balancer\_name](#input\_load\_balancer\_name) | The name for the default load balancer, uses a module label name if left empty | `string` | `""` | no |
+| <a name="input_load_balancer_name_max_length"></a> [load\_balancer\_name\_max\_length](#input\_load\_balancer\_name\_max\_length) | The max length of characters for the load balancer. | `number` | `32` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_noncurrent_version_expiration_days"></a> [noncurrent\_version\_expiration\_days](#input\_noncurrent\_version\_expiration\_days) | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
@@ -286,6 +289,7 @@ Available targets:
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_target_group_additional_tags"></a> [target\_group\_additional\_tags](#input\_target\_group\_additional\_tags) | The additional tags to apply to the target group | `map(string)` | `{}` | no |
 | <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
+| <a name="input_target_group_name_max_length"></a> [target\_group\_name\_max\_length](#input\_target\_group\_name\_max\_length) | The max length of characters for the target group. | `number` | `32` | no |
 | <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | The port for the default target group | `number` | `80` | no |
 | <a name="input_target_group_protocol"></a> [target\_group\_protocol](#input\_target\_group\_protocol) | The protocol for the default target group HTTP or HTTPS | `string` | `"HTTP"` | no |
 | <a name="input_target_group_target_type"></a> [target\_group\_target\_type](#input\_target\_group\_target\_type) | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the target group | `string` | `"ip"` | no |

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.14.0 |
+| <a name="module_default_load_balancer_label"></a> [default\_load\_balancer\_label](#module\_default\_load\_balancer\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.13.0 |
+| <a name="module_default_load_balancer_label"></a> [default\_load\_balancer\_label](#module\_default\_load\_balancer\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 
@@ -88,6 +89,8 @@
 | <a name="input_lifecycle_rule_enabled"></a> [lifecycle\_rule\_enabled](#input\_lifecycle\_rule\_enabled) | A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled. | `bool` | `false` | no |
 | <a name="input_listener_http_fixed_response"></a> [listener\_http\_fixed\_response](#input\_listener\_http\_fixed\_response) | Have the HTTP listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
 | <a name="input_listener_https_fixed_response"></a> [listener\_https\_fixed\_response](#input\_listener\_https\_fixed\_response) | Have the HTTPS listener return a fixed response for the default action. | <pre>object({<br>    content_type = string<br>    message_body = string<br>    status_code  = string<br>  })</pre> | `null` | no |
+| <a name="input_load_balancer_name"></a> [load\_balancer\_name](#input\_load\_balancer\_name) | The name for the default load balancer, uses a module label name if left empty | `string` | `""` | no |
+| <a name="input_load_balancer_name_max_length"></a> [load\_balancer\_name\_max\_length](#input\_load\_balancer\_name\_max\_length) | The max length of characters for the load balancer. | `number` | `32` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_noncurrent_version_expiration_days"></a> [noncurrent\_version\_expiration\_days](#input\_noncurrent\_version\_expiration\_days) | Specifies when noncurrent s3 log versions expire | `number` | `90` | no |
@@ -102,6 +105,7 @@
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | <a name="input_target_group_additional_tags"></a> [target\_group\_additional\_tags](#input\_target\_group\_additional\_tags) | The additional tags to apply to the target group | `map(string)` | `{}` | no |
 | <a name="input_target_group_name"></a> [target\_group\_name](#input\_target\_group\_name) | The name for the default target group, uses a module label name if left empty | `string` | `""` | no |
+| <a name="input_target_group_name_max_length"></a> [target\_group\_name\_max\_length](#input\_target\_group\_name\_max\_length) | The max length of characters for the target group. | `number` | `32` | no |
 | <a name="input_target_group_port"></a> [target\_group\_port](#input\_target\_group\_port) | The port for the default target group | `number` | `80` | no |
 | <a name="input_target_group_protocol"></a> [target\_group\_protocol](#input\_target\_group\_protocol) | The protocol for the default target group HTTP or HTTPS | `string` | `"HTTP"` | no |
 | <a name="input_target_group_target_type"></a> [target\_group\_target\_type](#input\_target\_group\_target\_type) | The type (`instance`, `ip` or `lambda`) of targets that can be registered with the target group | `string` | `"ip"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -18,6 +18,8 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_access_logs"></a> [access\_logs](#module\_access\_logs) | cloudposse/lb-s3-bucket/aws | 0.14.0 |
+| <a name="module_default_load_balancer_label"></a> [default\_load\_balancer\_label](#module\_default\_load\_balancer\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_default_target_group_label"></a> [default\_target\_group\_label](#module\_default\_target\_group\_label) | cloudposse/label/null | 0.24.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.24.1 |
 

--- a/main.tf
+++ b/main.tf
@@ -54,11 +54,19 @@ module "access_logs" {
   context                            = module.this.context
 }
 
+module "default_load_balancer_label" {
+  source          = "cloudposse/label/null"
+  version         = "0.24.1"
+  attributes      = concat(module.this.attributes, ["default"])
+  id_length_limit = var.load_balancer_name_max_length
+  context         = module.this.context
+}
+
 resource "aws_lb" "default" {
   #bridgecrew:skip=BC_AWS_NETWORKING_41 - Skipping Ensure that ALB Drops HTTP Headers
   #bridgecrew:skip=BC_AWS_LOGGING_22 - Skipping Ensure ELBv2 has Access Logging Enabled
   count              = module.this.enabled ? 1 : 0
-  name               = module.this.id
+  name               = var.load_balancer_name == "" ? module.default_load_balancer_label.id : substr(var.lb_name, 0, var.load_balancer_name_max_length)
   tags               = module.this.tags
   internal           = var.internal
   load_balancer_type = "application"
@@ -83,15 +91,16 @@ resource "aws_lb" "default" {
 }
 
 module "default_target_group_label" {
-  source     = "cloudposse/label/null"
-  version    = "0.24.1"
-  attributes = concat(module.this.attributes, ["default"])
-  context    = module.this.context
+  source          = "cloudposse/label/null"
+  version         = "0.24.1"
+  attributes      = concat(module.this.attributes, ["default"])
+  id_length_limit = var.target_group_name_max_length
+  context         = module.this.context
 }
 
 resource "aws_lb_target_group" "default" {
   count                = module.this.enabled ? 1 : 0
-  name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
+  name                 = var.target_group_name == "" ? module.default_target_group_label.id : substr(var.target_group_name, 0, var.target_group_name_max_length)
   port                 = var.target_group_port
   protocol             = var.target_group_protocol
   vpc_id               = var.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_lb" "default" {
   #bridgecrew:skip=BC_AWS_NETWORKING_41 - Skipping Ensure that ALB Drops HTTP Headers
   #bridgecrew:skip=BC_AWS_LOGGING_22 - Skipping Ensure ELBv2 has Access Logging Enabled
   count              = module.this.enabled ? 1 : 0
-  name               = var.load_balancer_name == "" ? module.default_load_balancer_label.id : substr(var.lb_name, 0, var.load_balancer_name_max_length)
+  name               = var.load_balancer_name == "" ? module.default_load_balancer_label.id : substr(var.load_balancer_name, 0, var.load_balancer_name_max_length)
   tags               = module.this.tags
   internal           = var.internal
   load_balancer_type = "application"

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,6 @@ module "access_logs" {
 module "default_load_balancer_label" {
   source          = "cloudposse/label/null"
   version         = "0.24.1"
-  attributes      = concat(module.this.attributes, ["default"])
   id_length_limit = var.load_balancer_name_max_length
   context         = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -212,6 +212,12 @@ variable "target_group_name" {
   description = "The name for the default target group, uses a module label name if left empty"
 }
 
+variable "target_group_name_max_length" {
+  type        = number
+  default     = 32
+  description = "The max length of characters for the target group."
+}
+
 variable "target_group_target_type" {
   type        = string
   default     = "ip"
@@ -305,4 +311,16 @@ variable "security_group_enabled" {
   type        = bool
   description = "Enables the security group"
   default     = true
+}
+
+variable "load_balancer_name" {
+  type        = string
+  default     = ""
+  description = "The name for the default load balancer, uses a module label name if left empty"
+}
+
+variable "load_balancer_name_max_length" {
+  type        = number
+  default     = 32
+  description = "The max length of characters for the load balancer."
 }


### PR DESCRIPTION
## what
* Ensure target group and load balancer names cannot exceed their max length
* Expose `*_max_length` variables in case AWS changes their max length in the future
* Override `load_balancer_name`, similar to `target_group_name`

## why
* To prevent exceeding the max lengths of the tg and lb so the module will be applied correctly

## references
* Closes https://github.com/cloudposse/terraform-aws-alb/issues/27
* [API_CreateTargetGroup](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html)
    > This name must be unique per region per account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, and must not begin or end with a hyphen.
* [API_CreateLoadBalancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html)
    > This name must be unique per region per account, can have a maximum of 32 characters, must contain only alphanumeric characters or hyphens, must not begin or end with a hyphen, and must not begin with "internal-". 

