### PR TITLE
Add `module.this.enabled` check to listener's `count`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "default_target_group_label" {
 }
 
 resource "aws_lb_target_group" "default" {
-  count                = module.this.enabled && listener_http_fixed_response == null && listener_https_fixed_response == null ? 1 : 0
+  count                = module.this.enabled && var.listener_http_fixed_response == null && var.listener_https_fixed_response == null ? 1 : 0
   name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
   port                 = var.target_group_port
   protocol             = var.target_group_protocol

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "default_target_group_label" {
 }
 
 resource "aws_lb_target_group" "default" {
-  count                = module.this.enabled ? 1 : 0
+  count                = module.this.enabled && listener_http_fixed_response == null && listener_https_fixed_response == null ? 1 : 0
   name                 = var.target_group_name == "" ? module.default_target_group_label.id : var.target_group_name
   port                 = var.target_group_port
   protocol             = var.target_group_protocol

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "aws_lb_target_group" "default" {
 resource "aws_lb_listener" "http_forward" {
   #bridgecrew:skip=BC_AWS_GENERAL_43 - Skipping Ensure that load balancer is using TLS 1.2.
   #bridgecrew:skip=BC_AWS_NETWORKING_29 - Skipping Ensure ALB Protocol is HTTPS
-  count             = var.http_enabled && var.http_redirect != true ? 1 : 0
+  count             = module.this.enabled && var.http_enabled && var.http_redirect != true ? 1 : 0
   load_balancer_arn = join("", aws_lb.default.*.arn)
   port              = var.http_port
   protocol          = "HTTP"


### PR DESCRIPTION
## what
* Add `module.this.enabled` check to listener's `count`

## why
* To ensure this module can be properly disabled using `enabled = false`

## references
* Closes https://github.com/cloudposse/terraform-aws-alb/issues/90
* Closes https://github.com/cloudposse/terraform-aws-alb/issues/94

