### PR TITLE
Consider Removing Access Logs Module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,22 +38,6 @@ resource "aws_security_group_rule" "https_ingress" {
   security_group_id = join("", aws_security_group.default.*.id)
 }
 
-module "access_logs" {
-  source                             = "cloudposse/lb-s3-bucket/aws"
-  version                            = "0.14.1"
-  enabled                            = module.this.enabled && var.access_logs_enabled && var.access_logs_s3_bucket_id == null
-  attributes                         = compact(concat(module.this.attributes, ["alb", "access", "logs"]))
-  lifecycle_rule_enabled             = var.lifecycle_rule_enabled
-  enable_glacier_transition          = var.enable_glacier_transition
-  expiration_days                    = var.expiration_days
-  glacier_transition_days            = var.glacier_transition_days
-  noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
-  noncurrent_version_transition_days = var.noncurrent_version_transition_days
-  standard_transition_days           = var.standard_transition_days
-  force_destroy                      = var.alb_access_logs_s3_bucket_force_destroy
-  context                            = module.this.context
-}
-
 module "default_load_balancer_label" {
   source          = "cloudposse/label/null"
   version         = "0.25.0"

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "aws_lb" "default" {
   drop_invalid_header_fields       = var.drop_invalid_header_fields
 
   access_logs {
-    bucket  = try(element(compact([var.access_logs_s3_bucket_id, module.access_logs.bucket_id]), 0), "")
+    bucket  = var.access_logs_s3_bucket_id
     prefix  = var.access_logs_prefix
     enabled = var.access_logs_enabled
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -54,8 +54,3 @@ output "listener_arns" {
     concat(aws_lb_listener.http_forward.*.arn, aws_lb_listener.http_redirect.*.arn, aws_lb_listener.https.*.arn)
   )
 }
-
-output "access_logs_bucket_id" {
-  description = "The S3 bucket ID for access logs"
-  value       = module.access_logs.bucket_id
-}

--- a/variables.tf
+++ b/variables.tf
@@ -188,12 +188,6 @@ variable "health_check_matcher" {
   description = "The HTTP response codes to indicate a healthy check"
 }
 
-variable "alb_access_logs_s3_bucket_force_destroy" {
-  type        = bool
-  default     = false
-  description = "A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error"
-}
-
 variable "target_group_port" {
   type        = number
   default     = 80
@@ -248,48 +242,6 @@ variable "listener_https_fixed_response" {
     status_code  = string
   })
   default = null
-}
-
-variable "lifecycle_rule_enabled" {
-  type        = bool
-  description = "A boolean that indicates whether the s3 log bucket lifecycle rule should be enabled."
-  default     = false
-}
-
-variable "enable_glacier_transition" {
-  type        = bool
-  description = "Enables the transition of lb logs to AWS Glacier"
-  default     = true
-}
-
-variable "glacier_transition_days" {
-  type        = number
-  description = "Number of days after which to move s3 logs to the glacier storage tier"
-  default     = 60
-}
-
-variable "expiration_days" {
-  type        = number
-  description = "Number of days after which to expunge s3 logs"
-  default     = 90
-}
-
-variable "noncurrent_version_expiration_days" {
-  type        = number
-  description = "Specifies when noncurrent s3 log versions expire"
-  default     = 90
-}
-
-variable "noncurrent_version_transition_days" {
-  type        = number
-  description = "Specifies when noncurrent s3 log versions transition"
-  default     = 30
-}
-
-variable "standard_transition_days" {
-  type        = number
-  description = "Number of days to persist logs in standard storage tier before moving to the infrequent access tier"
-  default     = 30
 }
 
 variable "stickiness" {


### PR DESCRIPTION
## what
* Removed access_logs module

## why
* Disabling the access_logs module by supplying existing bucket_id results in errors from terraform and count for the alb_service_account not knowing how many resources to create because terraform hasn't been created yet.
* This makes the module more simple while allowing someone to easily spin up the same module code at the same level as the alb module and pass in the bucket information

## important
* this could be considered a breaking change and necessary to rev the major, however it wouldn't be difficult to migrate the module state up one level as an upgrade path

## example

```hcl
module "access_logs" {
  source                             = "cloudposse/lb-s3-bucket/aws"
  version                            = "0.14.1"
  enabled                            = module.this.enabled && var.access_logs_enabled && var.access_logs_s3_bucket_id == null
  attributes                         = compact(concat(module.this.attributes, ["alb", "access", "logs"]))
  lifecycle_rule_enabled             = var.lifecycle_rule_enabled
  enable_glacier_transition          = var.enable_glacier_transition
  expiration_days                    = var.expiration_days
  glacier_transition_days            = var.glacier_transition_days
  noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
  noncurrent_version_transition_days = var.noncurrent_version_transition_days
  standard_transition_days           = var.standard_transition_days
  force_destroy                      = var.alb_access_logs_s3_bucket_force_destroy
  context                            = module.this.context
}

module "alb" {
    source = "cloudposse/alb/aws"
    # Cloud Posse recommends pinning every module to a specific version
    # version     = "x.x.x"
    namespace                               = var.namespace
    stage                                   = var.stage
    name                                    = var.name
    attributes                              = var.attributes
    delimiter                               = var.delimiter
    vpc_id                                  = module.vpc.vpc_id
    security_group_ids                      = [module.vpc.vpc_default_security_group_id]
    subnet_ids                              = module.subnets.public_subnet_ids
    internal                                = var.internal
    http_enabled                            = var.http_enabled
    http_redirect                           = var.http_redirect
    access_logs_enabled                     = var.access_logs_enabled
    access_logs_s3_bucket_id                = module.access_logs.bucket_id
    cross_zone_load_balancing_enabled       = var.cross_zone_load_balancing_enabled
    http2_enabled                           = var.http2_enabled
    idle_timeout                            = var.idle_timeout
    ip_address_type                         = var.ip_address_type
    deletion_protection_enabled             = var.deletion_protection_enabled
    deregistration_delay                    = var.deregistration_delay
    health_check_path                       = var.health_check_path
    health_check_timeout                    = var.health_check_timeout
    health_check_healthy_threshold          = var.health_check_healthy_threshold
    health_check_unhealthy_threshold        = var.health_check_unhealthy_threshold
    health_check_interval                   = var.health_check_interval
    health_check_matcher                    = var.health_check_matcher
    target_group_port                       = var.target_group_port
    target_group_target_type                = var.target_group_target_type
    stickiness                              = var.stickiness
    tags                                    = var.tags
  }
```


