### PR TITLE
Fix default target group count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,7 @@ module "default_target_group_label" {
 }
 
 resource "aws_lb_target_group" "default" {
-  count                = module.this.enabled && var.listener_http_fixed_response == null && var.listener_https_fixed_response == null ? 1 : 0
+  count                = module.this.enabled ? 1 : 0
   name                 = var.target_group_name == "" ? module.default_target_group_label.id : substr(var.target_group_name, 0, var.target_group_name_max_length)
   port                 = var.target_group_port
   protocol             = var.target_group_protocol


### PR DESCRIPTION
## what
* I have `listener_https_fixed_response` but still need the default target group created in this module. It used to work before this PR `listener_https_fixed_response`. Do know see why it should not get created when we have `listener_https_fixed_response`
