### PR TITLE
feat: add variable to support health check protocol different from traffic's

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Available targets:
 | <a name="input_health_check_matcher"></a> [health\_check\_matcher](#input\_health\_check\_matcher) | The HTTP response codes to indicate a healthy check | `string` | `"200-399"` | no |
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | The destination for the health check request | `string` | `"/"` | no |
 | <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | The port to use for the healthcheck | `string` | `"traffic-port"` | no |
+| <a name="input_health_check_protocol"></a> [health\_check\_protocol](#input\_health\_check\_protocol) | The protocol to use for the healthcheck. If not specified, same as the traffic protocol | `string` | `null` | no |
 | <a name="input_health_check_timeout"></a> [health\_check\_timeout](#input\_health\_check\_timeout) | The amount of time to wait in seconds before failing a health check request | `number` | `10` | no |
 | <a name="input_health_check_unhealthy_threshold"></a> [health\_check\_unhealthy\_threshold](#input\_health\_check\_unhealthy\_threshold) | The number of consecutive health check failures required before considering the target unhealthy | `number` | `2` | no |
 | <a name="input_http2_enabled"></a> [http2\_enabled](#input\_http2\_enabled) | A boolean flag to enable/disable HTTP/2 | `bool` | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -68,6 +68,7 @@
 | <a name="input_health_check_matcher"></a> [health\_check\_matcher](#input\_health\_check\_matcher) | The HTTP response codes to indicate a healthy check | `string` | `"200-399"` | no |
 | <a name="input_health_check_path"></a> [health\_check\_path](#input\_health\_check\_path) | The destination for the health check request | `string` | `"/"` | no |
 | <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | The port to use for the healthcheck | `string` | `"traffic-port"` | no |
+| <a name="input_health_check_protocol"></a> [health\_check\_protocol](#input\_health\_check\_protocol) | The protocol to use for the healthcheck. If not specified, same as the traffic protocol | `string` | `null` | no |
 | <a name="input_health_check_timeout"></a> [health\_check\_timeout](#input\_health\_check\_timeout) | The amount of time to wait in seconds before failing a health check request | `number` | `10` | no |
 | <a name="input_health_check_unhealthy_threshold"></a> [health\_check\_unhealthy\_threshold](#input\_health\_check\_unhealthy\_threshold) | The number of consecutive health check failures required before considering the target unhealthy | `number` | `2` | no |
 | <a name="input_http2_enabled"></a> [http2\_enabled](#input\_http2\_enabled) | A boolean flag to enable/disable HTTP/2 | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "aws_lb_target_group" "default" {
   slow_start           = var.slow_start
 
   health_check {
-    protocol            = var.target_group_protocol
+    protocol            = var.health_check_protocol != null ? var.health_check_protocol : var.target_group_protocol
     path                = var.health_check_path
     port                = var.health_check_port
     timeout             = var.health_check_timeout

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,12 @@ variable "health_check_port" {
   description = "The port to use for the healthcheck"
 }
 
+variable "health_check_protocol" {
+  type        = string
+  default     = null
+  description = "The protocol to use for the healthcheck. If not specified, same as the traffic protocol"
+}
+
 variable "health_check_timeout" {
   type        = number
   default     = 10


### PR DESCRIPTION
## what
Add variable to support health check protocol different from traffic's


## why
My system uses HTTP for the health check but HTTPS for data traffic.   
Add a new variable to support this use case.

## references
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group#health_check

