### PR TITLE
Add http_ingress_source_security_group_ids and https_ingress_source_s…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,16 @@ resource "aws_security_group_rule" "http_ingress" {
   security_group_id = join("", aws_security_group.default.*.id)
 }
 
+resource "aws_security_group_rule" "http_ingress_from_sg" {
+  for_each                 = module.this.enabled && var.security_group_enabled && var.http_enabled ? toset(var.http_ingress_source_security_group_ids) : []
+  type                     = "ingress"
+  from_port                = var.http_port
+  to_port                  = var.http_port
+  protocol                 = "tcp"
+  source_security_group_id = each.key
+  security_group_id        = join("", aws_security_group.default.*.id)
+}
+
 resource "aws_security_group_rule" "https_ingress" {
   count             = module.this.enabled && var.security_group_enabled && var.https_enabled ? 1 : 0
   type              = "ingress"
@@ -36,6 +46,16 @@ resource "aws_security_group_rule" "https_ingress" {
   cidr_blocks       = var.https_ingress_cidr_blocks
   prefix_list_ids   = var.https_ingress_prefix_list_ids
   security_group_id = join("", aws_security_group.default.*.id)
+}
+
+resource "aws_security_group_rule" "https_ingress_from_sg" {
+  for_each                 = module.this.enabled && var.security_group_enabled && var.https_enabled ? toset(var.https_ingress_source_security_group_ids) : []
+  type                     = "ingress"
+  from_port                = var.https_port
+  to_port                  = var.https_port
+  protocol                 = "tcp"
+  source_security_group_id = each.key
+  security_group_id        = join("", aws_security_group.default.*.id)
 }
 
 module "access_logs" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,12 @@ variable "http_ingress_prefix_list_ids" {
   description = "List of prefix list IDs for allowing access to HTTP ingress security group"
 }
 
+variable "http_ingress_source_security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "Security group IDs to allow access to HTTP ingress security group"
+}
+
 variable "certificate_arn" {
   type        = string
   default     = ""
@@ -78,6 +84,12 @@ variable "https_ingress_prefix_list_ids" {
   type        = list(string)
   default     = []
   description = "List of prefix list IDs for allowing access to HTTPS ingress security group"
+}
+
+variable "https_ingress_source_security_group_ids" {
+  type        = list(string)
+  default     = []
+  description = "Security group IDs to allow access to HTTPS ingress security group"
 }
 
 variable "https_ssl_policy" {


### PR DESCRIPTION
…ecurity_group_ids input variables

## what
* This change adds the option to allow ingress traffic to the HTTP/HTTPS ports from other existing security groups. It creates a `aws_security_group_rule` resource per security group ID.

## why
* The only controls over which traffic was allowed to the ALB SG were CIDR ranges and prefix lists. This means to allow traffic from another SG you had to add a separate `aws_security_group_rule` resource.
* This change adds more complete security group support in the module.
