### PR TITLE
Remove access_logs config that attempts to create bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,29 +38,6 @@ resource "aws_security_group_rule" "https_ingress" {
   security_group_id = join("", aws_security_group.default.*.id)
 }
 
-module "access_logs" {
-  source  = "cloudposse/lb-s3-bucket/aws"
-  version = "0.16.0"
-
-  enabled = module.this.enabled && var.access_logs_enabled && var.access_logs_s3_bucket_id == null
-
-  attributes = compact(concat(module.this.attributes, ["alb", "access", "logs"]))
-
-  force_destroy                 = var.alb_access_logs_s3_bucket_force_destroy
-  force_destroy_enabled         = var.alb_access_logs_s3_bucket_force_destroy_enabled
-  lifecycle_configuration_rules = var.lifecycle_configuration_rules
-
-  # TODO: deprecate these inputs in favor of `lifecycle_configuration_rules`
-  lifecycle_rule_enabled             = var.lifecycle_rule_enabled
-  enable_glacier_transition          = var.enable_glacier_transition
-  expiration_days                    = var.expiration_days
-  glacier_transition_days            = var.glacier_transition_days
-  noncurrent_version_expiration_days = var.noncurrent_version_expiration_days
-  noncurrent_version_transition_days = var.noncurrent_version_transition_days
-  standard_transition_days           = var.standard_transition_days
-
-  context = module.this.context
-}
 
 module "default_load_balancer_label" {
   source          = "cloudposse/label/null"
@@ -92,7 +69,7 @@ resource "aws_lb" "default" {
   preserve_host_header             = var.preserve_host_header
 
   access_logs {
-    bucket  = try(element(compact([var.access_logs_s3_bucket_id, module.access_logs.bucket_id]), 0), "")
+    bucket  = var.access_logs_s3_bucket_id
     prefix  = var.access_logs_prefix
     enabled = var.access_logs_enabled
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,8 +59,3 @@ output "listener_arns" {
     concat(aws_lb_listener.http_forward.*.arn, aws_lb_listener.http_redirect.*.arn, aws_lb_listener.https.*.arn)
   )
 }
-
-output "access_logs_bucket_id" {
-  description = "The S3 bucket ID for access logs"
-  value       = module.access_logs.bucket_id
-}

--- a/variables.tf
+++ b/variables.tf
@@ -86,18 +86,6 @@ variable "https_ssl_policy" {
   default     = "ELBSecurityPolicy-2015-05"
 }
 
-variable "access_logs_prefix" {
-  type        = string
-  default     = ""
-  description = "The S3 log bucket prefix"
-}
-
-variable "access_logs_enabled" {
-  type        = bool
-  default     = true
-  description = "A boolean flag to enable/disable access_logs"
-}
-
 variable "access_logs_s3_bucket_id" {
   type        = string
   default     = null
@@ -198,26 +186,6 @@ variable "health_check_matcher" {
   type        = string
   default     = "200-399"
   description = "The HTTP response codes to indicate a healthy check"
-}
-
-variable "alb_access_logs_s3_bucket_force_destroy" {
-  type        = bool
-  default     = false
-  description = "A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error"
-}
-
-variable "alb_access_logs_s3_bucket_force_destroy_enabled" {
-  type        = bool
-  default     = false
-  description = <<-EOT
-    When `true`, permits `force_destroy` to be set to `true`.
-    This is an extra safety precaution to reduce the chance that Terraform will destroy and recreate
-    your S3 bucket, causing COMPLETE LOSS OF ALL DATA even if it was stored in Glacier.
-    WARNING: Upgrading this module from a version prior to 0.27.0 to this version
-      will cause Terraform to delete your existing S3 bucket CAUSING COMPLETE DATA LOSS
-      unless you follow the upgrade instructions on the Wiki [here](https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS)).
-      See additional instructions for upgrading from v0.27.0 to v0.28.0 [here](https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.28.0-and-AWS-provider-v4-(POTENTIAL-DATA-LOSS)).
-    EOT
 }
 
 variable "target_group_port" {


### PR DESCRIPTION
## what
* removes access_logs config items that would force the creation of an access_logs bucket

## why
* In the upstream config, specifying your own, doesn't-exist-yet bucket for access logs creates a race-ish condition where terraform can't predict a `count` for resources b/c it can't determine if a bucket will be created or not.
```
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket.aws_s3_bucket.s3_user.s3_user/main.tf line 7, in resource "aws_iam_user" "default":
│    7:   count                = module.this.enabled ? 1 : 0
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket.aws_s3_bucket.s3_user.s3_user/main.tf line 58, in module "store_write":
│   58:   count = module.this.enabled && var.ssm_enabled && var.create_iam_access_key ? 1 : 0
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket.aws_s3_bucket/main.tf line 27, in data "aws_partition" "current":
│   27: data "aws_partition" "current" { count = local.enabled ? 1 : 0 }
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket.aws_s3_bucket/main.tf line 28, in data "aws_canonical_user_id" "default":
│   28: data "aws_canonical_user_id" "default" { count = local.enabled ? 1 : 0 }
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket.aws_s3_bucket/main.tf line 37, in resource "aws_s3_bucket" "default":
│   37:   count         = local.enabled ? 1 : 0
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket.aws_s3_bucket/replication.tf line 9, in data "aws_iam_policy_document" "replication_sts":
│    9:   count = local.replication_enabled ? 1 : 0
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket/sqs_notifications.tf line 8, in data "aws_caller_identity" "current":
│    8: data "aws_caller_identity" "current" { count = local.enabled ? 1 : 0 }
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs.s3_bucket/sqs_notifications.tf line 9, in data "aws_partition" "current":
│    9: data "aws_partition" "current" { count = local.enabled ? 1 : 0 }
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
╷
│ Error: Invalid count argument
│
│   on .terraform/modules/staging-v2.alb_config.alb.access_logs/main.tf line 2, in data "aws_elb_service_account" "default":
│    2:   count = module.this.enabled ? 1 : 0
│
│ The "count" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply
│ only the resources that the count depends on.
╵
Releasing state lock. This may take a few moments...
```
This whole module ends up being a bunch of spaghetti code that I don't have patience for.
