### PR TITLE
Fixes #134 - Does not create http_forward when aws_lb_target_group.default is disabled

### DIFF
--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -81,7 +81,7 @@
 | <a name="input_https_ingress_cidr_blocks"></a> [https\_ingress\_cidr\_blocks](#input\_https\_ingress\_cidr\_blocks) | List of CIDR blocks to allow in HTTPS security group | `list(string)` | <pre>[<br/>  "0.0.0.0/0",<br/>  "::/0"<br/>]</pre> | no |
 | <a name="input_https_ingress_prefix_list_ids"></a> [https\_ingress\_prefix\_list\_ids](#input\_https\_ingress\_prefix\_list\_ids) | List of prefix list IDs for allowing access to HTTPS ingress security group | `list(string)` | `[]` | no |
 | <a name="input_https_port"></a> [https\_port](#input\_https\_port) | The port for the HTTPS listener | `number` | `443` | no |
-| <a name="input_https_ssl_policy"></a> [https\_ssl\_policy](#input\_https\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-2015-05"` | no |
+| <a name="input_https_ssl_policy"></a> [https\_ssl\_policy](#input\_https\_ssl\_policy) | The name of the SSL Policy for the listener | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br/>Set to `0` for unlimited length.<br/>Set to `null` for keep the existing setting, which defaults to `0`.<br/>Does not affect `id_full`. | `number` | `null` | no |
 | <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle | `number` | `60` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | A boolean flag to determine whether the ALB should be internal | `bool` | `false` | no |


### PR DESCRIPTION
## What

Fixes #134 - Does not create http_forward when aws_lb_target_group.default is disabled

* disables aws_lb_listener.http_forward when default_target_group is not enabled
* target_group is required when type is 'redirect'

## Why

See #134.  Fixes this Validation error when default_target_group_enabled == 0 :
```
module.alb.aws_lb_listener.http_forward[0]: Creating...
╷
│ Error: creating ELBv2 Listener
(arn:aws:elasticloadbalancing:...:...:loadbalancer/...):
ValidationError: A target group ARN must be specified
│       status code: 400, request id:
7cf9d727-fc77-4d32-a160-deadbeefcafe
│
│   with module.alb.aws_lb_listener.http_forward[0],
│   on .terraform/modules/alb/main.tf line 150, in resource
"aws_lb_listener" "http_forward":
│  150: resource "aws_lb_listener" "http_forward" {

```

## references

closes #134