### PR TITLE
feat(alb): add desync mitigation mode support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,7 @@ resource "aws_lb" "default" {
   ip_address_type                  = var.ip_address_type
   enable_deletion_protection       = var.deletion_protection_enabled
   drop_invalid_header_fields       = var.drop_invalid_header_fields
+  desync_mitigation_mode           = var.desync_mitigation_mode
   preserve_host_header             = var.preserve_host_header
   xff_header_processing_mode       = var.xff_header_processing_mode
   client_keep_alive                = var.client_keep_alive

--- a/variables.tf
+++ b/variables.tf
@@ -185,6 +185,17 @@ variable "drop_invalid_header_fields" {
   description = "Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false)."
 }
 
+variable "desync_mitigation_mode" {
+  type        = string
+  default     = "defensive"
+  description = "How the load balancer handles requests that might pose a security risk to an application due to HTTP desync. Valid values are `monitor`, `defensive` (default), `strictest`."
+
+  validation {
+    condition     = contains(["monitor", "defensive", "strictest"], var.desync_mitigation_mode)
+    error_message = "Allowed values: `monitor`, `defensive`, or `strictest`."
+  }
+}
+
 variable "health_check_path" {
   type        = string
   default     = "/"


### PR DESCRIPTION
## What and Why

This introduces support for configuring the desync mitigation mode on the AWS load balancer resource. It adds a new variable to control how the load balancer handles potentially risky HTTP desync requests, improving security configuration flexibility.

New desync mitigation mode support:

* Added the `desync_mitigation_mode` argument to the `aws_lb` resource in `main.tf`, allowing the load balancer's HTTP desync handling to be configured.
* Introduced a new `desync_mitigation_mode` variable in `variables.tf` with validation for accepted values (`monitor`, `defensive`, `strictest`) and a default of `defensive`.